### PR TITLE
Removed residue method "segment"

### DIFF
--- a/src/LazySession.php
+++ b/src/LazySession.php
@@ -53,11 +53,6 @@ final class LazySession implements SessionInterface
         return $this->getProxiedSession()->isRegenerated();
     }
 
-    public function segment(string $name) : SegmentInterface
-    {
-        return $this->getProxiedSession()->segment($name);
-    }
-
     public function toArray() : array
     {
         return $this->getProxiedSession()->toArray();


### PR DESCRIPTION
I think the method is some residue because as returned type is declared
SegmentInterface but this interface is not even defined.
Method seems to be not tested and not used anywhere else.

