### PR TITLE
Updated PHPUnit dependency and removed conflicts as it is no longer needed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,11 +27,8 @@
         "psr/container": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0.9",
+        "phpunit/phpunit": "^6.4.1",
         "zendframework/zend-coding-standard": "~1.0.0"
-    },
-    "conflict": {
-        "phpspec/prophecy": "<1.7.2"
     },
     "suggest": {
         "zendframework/zend-expressive-csrf": "^1.0 || ^1.0-dev for CSRF protection capabilities",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "d2d1c3019a4ae7878cae21e26d4043e1",
+    "content-hash": "a86e64f954d0a6bf37a4cdbd7c806fd7",
     "packages": [
         {
             "name": "http-interop/http-middleware",
@@ -818,16 +818,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.3.1",
+            "version": "6.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c0ff817b36a827e64bf5f57bc72278150cf30a77"
+                "reference": "b770d8ba7e60295ee91d69d5a5e01ae833cac220"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c0ff817b36a827e64bf5f57bc72278150cf30a77",
-                "reference": "c0ff817b36a827e64bf5f57bc72278150cf30a77",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b770d8ba7e60295ee91d69d5a5e01ae833cac220",
+                "reference": "b770d8ba7e60295ee91d69d5a5e01ae833cac220",
                 "shasum": ""
             },
             "require": {
@@ -872,7 +872,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.3.x-dev"
+                    "dev-master": "6.4.x-dev"
                 }
             },
             "autoload": {
@@ -898,7 +898,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-09-24T07:25:54+00:00"
+            "time": "2017-10-07T17:53:53+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",


### PR DESCRIPTION
Correct version of phpspec is already required in PHPUnit so we don't need to have conflict declaration