### PR TITLE
Explicit class constant visibility

### DIFF
--- a/docs/book/middleware.md
+++ b/docs/book/middleware.md
@@ -24,7 +24,7 @@ use Psr\Http\Message\ResponseInterface;
 
 class SessionMiddleware implements MiddlewareInterface
 {
-    const SESSION_ATTRIBUTE = 'session';
+    public const SESSION_ATTRIBUTE = 'session';
 
     private $persistence;
 

--- a/src/SessionMiddleware.php
+++ b/src/SessionMiddleware.php
@@ -14,7 +14,7 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class SessionMiddleware implements MiddlewareInterface
 {
-    const SESSION_ATTRIBUTE = 'session';
+    public const SESSION_ATTRIBUTE = 'session';
 
     /**
      * @var SessionPersistenceInterface


### PR DESCRIPTION
It is feature added in PHP 7.1 and as long as library supports only PHP 7.1
we should declare explicitly visibility of the class constants.

Closes #10