### PR TITLE
FIx error with resolve Psr\Http\Server\MiddlewareInterface

### DIFF
--- a/src/SessionMiddleware.php
+++ b/src/SessionMiddleware.php
@@ -7,10 +7,10 @@
 
 namespace Zend\Expressive\Session;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 
 class SessionMiddleware implements MiddlewareInterface
 {
@@ -26,10 +26,10 @@ class SessionMiddleware implements MiddlewareInterface
         $this->persistence = $persistence;
     }
 
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate) : ResponseInterface
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $session = new LazySession($this->persistence, $request);
-        $response = $delegate->process($request->withAttribute(self::SESSION_ATTRIBUTE, $session));
+        $response = $handler->handle($request->withAttribute(self::SESSION_ATTRIBUTE, $session));
         return $this->persistence->persistSession($session, $response);
     }
 }


### PR DESCRIPTION
Zend Expressive 3 throw error `Service "Zend\Expressive\Session\SessionMiddleware" did not to resolve to a Psr\Http\Server\MiddlewareInterface instance; resolved to "Zend\Expressive\Session\SessionMiddleware"`
This PR will fix this problem.