### PR TITLE
Support persistent sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,37 +2,24 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 1.2.0 - TBD
+## 1.2.0 - 2018-10-30
 
 ### Added
 
-- Nothing.
+- [#28](https://github.com/zendframework/zend-expressive-session/pull/28) adds a new interface, `SessionCookiePersistenceInterface`, defining:
+  - the constant `SESSION_LIFETIME_KEY`
+  - the method `persistSessionFor(int $duration) : void`, for developers to hint
+    to the persistence engine how long a session should last
+  - the method `getSessionLifetime() : int`, for persistence engines to
+    determine if a specific session duration was requested
 
 ### Changed
 
-- Nothing.
-
-### Deprecated
-
-- Nothing.
-
-### Removed
-
-- Nothing.
-
-### Fixed
-
-- Nothing.
-
-## 1.1.1 - TBD
-
-### Added
-
-- Nothing.
-
-### Changed
-
-- Nothing.
+- [#28](https://github.com/zendframework/zend-expressive-session/pull/28) updates both `Session` and `LazySession` to implement the new
+  `SessionCookiePersistenceInterface.  If a `SessionCookiePersistenceInterface::SESSION_LIFETIME_KEY`
+  is present in the initial session data provided to a `Session` instance, this
+  value will be used to indicate the requested session duration; otherwise, zero
+  is used, indicating the session should end when the browser is closed.
 
 ### Deprecated
 

--- a/docs/book/persistence.md
+++ b/docs/book/persistence.md
@@ -83,3 +83,29 @@ Considering that persistence implementations also _create_ the session instance,
 we recommend that implementations only create instances that implement the
 `SessionIdentifierAwareInterface` going forward in order to make themselves
 async compatible.
+
+## Persistent sessions
+
+- Since 1.2.0.
+
+If your session persistence supports persistent sessions &mdash; for example, by
+setting an `Expires` or `Max-Age` cookie directive &mdash; then you can opt to
+globally set a default session duration, or allow developers to hint a desired
+session duration via the session container using
+`SessionContainerPersistenceInterface::persistSessionFor()`.
+
+Implementations SHOULD honor the value of `SessionContainerPersistenceInterface::getSessionLifetime()`
+when persisting the session data. This could mean:
+
+- Ensuring that the session data will not be purged until after the specified
+  TTL value.
+- Setting an `Expires` or `Max-Age` cookie directive.
+
+In each case, the persistence engine should query the `Session` instance for a
+TTL value:
+
+```php
+$ttl = $session instanceof SessionContainerPersistenceInterface
+    ? $session->getSessionLifetime()
+    : $defaultLifetime; // likely 0, to indicate automatic expiry
+```

--- a/docs/book/persistence.md
+++ b/docs/book/persistence.md
@@ -88,14 +88,15 @@ async compatible.
 
 - Since 1.2.0.
 
-If your session persistence supports persistent sessions &mdash; for example, by
-setting an `Expires` or `Max-Age` cookie directive &mdash; then you can opt to
-globally set a default session duration, or allow developers to hint a desired
-session duration via the session container using
+If your persistence implementation supports persistent sessions &mdash; for
+example, by setting an `Expires` or `Max-Age` cookie directive &mdash; then you
+can opt to globally set a default session duration, or allow developers to hint
+a desired session duration via the session container using
 `SessionContainerPersistenceInterface::persistSessionFor()`.
 
 Implementations SHOULD honor the value of `SessionContainerPersistenceInterface::getSessionLifetime()`
-when persisting the session data. This could mean:
+when persisting the session data. This could mean either or both of the
+following:
 
 - Ensuring that the session data will not be purged until after the specified
   TTL value.
@@ -109,3 +110,6 @@ $ttl = $session instanceof SessionContainerPersistenceInterface
     ? $session->getSessionLifetime()
     : $defaultLifetime; // likely 0, to indicate automatic expiry
 ```
+
+`getSessionLifetime()` returns an `integer` value indicating the number of
+seconds the session should persist.

--- a/docs/book/session.md
+++ b/docs/book/session.md
@@ -219,18 +219,18 @@ $session->clear();
 
 - Since 1.2.0
 
-You can hint to the session persistence engine that the session cookie should
+You can hint to the session persistence engine how long the session should
 persist:
 
 ```php
 $session->persistSessionFor(60 * 60 * 24 * 7); // persist for 7 days
 ```
 
-To make the session cookie expire when the browser session is terminated
-(default behavior), use zero or a negative integer:
+To make the session expire when the browser session is terminated (default
+behavior), use zero or a negative integer:
 
 ```php
-$session->persistSessionFor(0); // expire cookie after session is over
+$session->persistSessionFor(0); // expire data after session is over
 ```
 
 ## Lazy Sessions

--- a/src/LazySession.php
+++ b/src/LazySession.php
@@ -19,7 +19,10 @@ use Psr\Http\Message\ServerRequestInterface;
  * method only on access to any of the various session data methods; otherwise,
  * the session will not be accessed, and, in most cases, started.
  */
-final class LazySession implements SessionInterface, SessionIdentifierAwareInterface
+final class LazySession implements
+    SessionCookiePersistenceInterface,
+    SessionIdentifierAwareInterface,
+    SessionInterface
 {
     /**
      * @var SessionPersistenceInterface
@@ -111,6 +114,32 @@ final class LazySession implements SessionInterface, SessionIdentifierAwareInter
         return $proxiedSession instanceof SessionIdentifierAwareInterface
             ? $proxiedSession->getId()
             : '';
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 1.2.0
+     */
+    public function persistSessionFor(int $duration) : void
+    {
+        $proxiedSession = $this->getProxiedSession();
+        if ($proxiedSession instanceof SessionCookiePersistenceInterface) {
+            $proxiedSession->persistSessionFor($duration);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 1.2.0
+     */
+    public function getSessionLifetime() : int
+    {
+        $proxiedSession = $this->getProxiedSession();
+        return $proxiedSession instanceof SessionCookiePersistenceInterface
+            ? $proxiedSession->getSessionLifetime()
+            : 0;
     }
 
     private function getProxiedSession() : SessionInterface

--- a/src/Session.php
+++ b/src/Session.php
@@ -9,7 +9,10 @@ declare(strict_types=1);
 
 namespace Zend\Expressive\Session;
 
-class Session implements SessionInterface, SessionIdentifierAwareInterface
+class Session implements
+    SessionCookiePersistenceInterface,
+    SessionIdentifierAwareInterface,
+    SessionInterface
 {
     /**
      * Current data within the session.
@@ -43,10 +46,21 @@ class Session implements SessionInterface, SessionIdentifierAwareInterface
      */
     private $originalData;
 
+    /**
+     * Lifetime of the session cookie.
+     *
+     * @var int
+     */
+    private $sessionLifetime = 0;
+
     public function __construct(array $data, string $id = '')
     {
         $this->data = $this->originalData = $data;
         $this->id = $id;
+
+        if (isset($data[SessionCookiePersistenceInterface::SESSION_LIFETIME_KEY])) {
+            $this->sessionLifetime = $data[SessionCookiePersistenceInterface::SESSION_LIFETIME_KEY];
+        }
     }
 
     /**
@@ -132,5 +146,26 @@ class Session implements SessionInterface, SessionIdentifierAwareInterface
     public function getId() : string
     {
         return $this->id;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 1.2.0
+     */
+    public function persistSessionFor(int $duration) : void
+    {
+        $this->sessionLifetime = $duration;
+        $this->set(SessionCookiePersistenceInterface::SESSION_LIFETIME_KEY, $duration);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 1.2.0
+     */
+    public function getSessionLifetime() : int
+    {
+        return $this->sessionLifetime;
     }
 }

--- a/src/SessionCookiePersistenceInterface.php
+++ b/src/SessionCookiePersistenceInterface.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-session for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-session/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Session;
+
+/**
+ * Allow marking session cookies as persistent.
+ *
+ * It can be useful to mark a session as persistent: e.g., for a "Remember Me"
+ * feature when logging a user into your system. PHP provides this capability
+ * via ext-session with the $lifetime argument to session_set_cookie_params()
+ * as well as by the session.cookie_lifetime INI setting. The latter will set
+ * the value for all session cookies sent (or until the value is changed via
+ * an ini_set() call), while the former will only affect cookies created during
+ * the current script lifetime.
+ *
+ * Persistence engines may, of course, allow setting a global lifetime. This
+ * interface allows developers to set the lifetime programmatically. Persistence
+ * implementations are encouraged to use the value to set the cookie lifetime
+ * when creating and returning a cookie. Additionally, to ensure the cookie
+ * lifetime originally requested is honored when a session is regenerated, we
+ * recommend persistence engines to store the TTL in the session data itself,
+ * so that it can be re-sent in such scenarios.
+ */
+interface SessionCookiePersistenceInterface
+{
+    const SESSION_LIFETIME_KEY = '__SESSION_TTL__';
+
+    /**
+     * Define how long the session cookie should live.
+     *
+     * Use this value to detail to the session persistence engine how long the
+     * session cookie should live.
+     *
+     * This value could be passed as the $lifetime value of
+     * session_set_cookie_params(), or used to create an Expires or Max-Age
+     * parameter for a session cookie.
+     *
+     * Since cookie lifetime is communicated by the server to the client, and
+     * not vice versa, the value should likely be persisted in the session
+     * itself, to ensure that session regeneration uses the same value. We
+     * recommend using the SESSION_LIFETIME_KEY value to communicate this.
+     *
+     * @param int $duration Number of seconds the cookie should persist for.
+     */
+    public function persistSessionFor(int $duration) : void;
+
+    /**
+     * Determine how long the session cookie should live.
+     *
+     * Generally, this will return the value provided to persistFor().
+     *
+     * If that method has not been called, the value can return one of the
+     * following:
+     *
+     * - 0 or a negative value, to indicate the cookie should be treated as a
+     *   session cookie, and expire when the window is closed. This should be
+     *   the default behavior.
+     * - If persistFor() was provided during session creation or anytime later,
+     *   the persistence engine should pull the TTL value from the session itself
+     *   and return it here. Typically, this value should be communicated via
+     *   the SESSION_LIFETIME_KEY value of the session.
+     */
+    public function getSessionLifetime() : int;
+}

--- a/test/SessionTest.php
+++ b/test/SessionTest.php
@@ -11,6 +11,7 @@ namespace ZendTest\Expressive\Session;
 
 use PHPUnit\Framework\TestCase;
 use Zend\Expressive\Session\Session;
+use Zend\Expressive\Session\SessionCookiePersistenceInterface;
 use Zend\Expressive\Session\SessionIdentifierAwareInterface;
 use Zend\Expressive\Session\SessionInterface;
 
@@ -141,5 +142,40 @@ class SessionTest extends TestCase
     {
         $session = new Session([], '1234abcd');
         $this->assertSame('1234abcd', $session->getId());
+    }
+
+    public function testImplementsSessionCookiePersistenceInterface()
+    {
+        $session = new Session([]);
+        $this->assertInstanceOf(SessionCookiePersistenceInterface::class, $session);
+    }
+
+    public function testDefaultSessionCookieLifetimeIsZero()
+    {
+        $session = new Session([]);
+        $this->assertSame(0, $session->getSessionLifetime());
+    }
+
+    public function testAllowsSettingCookieLifetime()
+    {
+        $session = new Session([]);
+        $session->persistSessionFor(60);
+        $this->assertSame(60, $session->getSessionLifetime());
+    }
+
+    public function testGetSessionLifetimeReturnsValueOfSessionLifetimeKeyWhenPresentInSession()
+    {
+        $session = new Session([
+            SessionCookiePersistenceInterface::SESSION_LIFETIME_KEY => 60,
+        ]);
+        $this->assertSame(60, $session->getSessionLifetime());
+    }
+
+    public function testPersistingSessionCookieLifetimeSetsLifetimeKeyInSessionData()
+    {
+        $session = new Session([]);
+        $session->persistSessionFor(60);
+        $this->assertTrue($session->has(SessionCookiePersistenceInterface::SESSION_LIFETIME_KEY));
+        $this->assertSame(60, $session->get(SessionCookiePersistenceInterface::SESSION_LIFETIME_KEY));
     }
 }


### PR DESCRIPTION
PHP supports persistent sessions by allowing developers to set the `session.cookie_lifetime` value, or to pass the `$lifetime` argument to `session_set_cookie_params()`. In each case, ext-session will then set an `Expires` directive in the `Set-Cookie` header associated with the session. These values are often manipulated at runtime to allow developers to set session cookie lifetimes based on specific criteria (e.g., a user checking a "remember me" box).

This patch adds the ability for developers to provide at runtime a TTL for the sesssion they are manipulating. It introduces a new interface, `SessionCookiePersistenceInterface`, with the methods `persistSessionFor(int $duration) : void` and `getSessionLifetime() : int`. The first can be used by developers to indicate the desired session lifetime; the second can be used by persistence engines in order to set the lifetime either in the persistence engine itself or in client-side artifacts such as session cookies.

In order to allow the lifetime to persist when a cookie is regenerated, I both recommend that the session stores the lifetime within its own data, and that `Session` instances use that value when present. I have implemented `Session` such that it does exactly this, using the value of `SessionCookiePersistenceInterface::SESSION_LIFETIME_KEY` as the session data key under which the lifetime is stored.

The value is specified and stored as an integer, as most existing systems expect an integer indicating the number of seconds the session should persist. Negative values and zero indicate expiry as soon as the current session is over (generally indicated by closing the window and/or browser).