### PR TITLE
Ability to use own session save handler

### DIFF
--- a/src/SaveHandlerInterface.php
+++ b/src/SaveHandlerInterface.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-session for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-session/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Session;
+
+use SessionHandlerInterface;
+
+/**
+ * SaveHandler Interface
+ *
+ * @see        http://php.net/session_set_save_handler
+ */
+interface SaveHandlerInterface extends SessionHandlerInterface
+{
+}

--- a/src/SessionMiddleware.php
+++ b/src/SessionMiddleware.php
@@ -23,8 +23,12 @@ class SessionMiddleware implements MiddlewareInterface
      */
     private $persistence;
 
-    public function __construct(SessionPersistenceInterface $persistence)
+    public function __construct(SessionPersistenceInterface $persistence, SaveHandlerInterface $saveHandler = null)
     {
+        if (null !== $saveHandler) {
+            session_set_save_handler($saveHandler, true);
+        }
+
         $this->persistence = $persistence;
     }
 

--- a/src/SessionMiddlewareFactory.php
+++ b/src/SessionMiddlewareFactory.php
@@ -16,7 +16,10 @@ class SessionMiddlewareFactory
     public function __invoke(ContainerInterface $container) : SessionMiddleware
     {
         return new SessionMiddleware(
-            $container->get(SessionPersistenceInterface::class)
+            $container->get(SessionPersistenceInterface::class),
+            $container->has(SaveHandlerInterface::class)
+                ? $container->get(SaveHandlerInterface::class)
+                : null
         );
     }
 }

--- a/test/SessionMiddlewareFactoryTest.php
+++ b/test/SessionMiddlewareFactoryTest.php
@@ -11,21 +11,42 @@ namespace ZendTest\Expressive\Session;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use Zend\Expressive\Session\SaveHandlerInterface;
 use Zend\Expressive\Session\SessionMiddleware;
 use Zend\Expressive\Session\SessionMiddlewareFactory;
 use Zend\Expressive\Session\SessionPersistenceInterface;
 
+/**
+ * @runTestsInSeparateProcesses
+ */
 class SessionMiddlewareFactoryTest extends TestCase
 {
-    public function testFactoryProducesMiddlewareWithSessionPersistenceInterfaceService()
+    public function testWithSessionPersistenceInterfaceServiceAndWithoutSaveHandlerInterfaceService()
     {
         $persistence = $this->prophesize(SessionPersistenceInterface::class)->reveal();
 
         $container = $this->prophesize(ContainerInterface::class);
         $container->get(SessionPersistenceInterface::class)->willReturn($persistence);
+        $container->has(SaveHandlerInterface::class)->willReturn(false);
 
         $factory = new SessionMiddlewareFactory();
+        $middleware = $factory($container->reveal());
 
+        $this->assertInstanceOf(SessionMiddleware::class, $middleware);
+        $this->assertAttributeSame($persistence, 'persistence', $middleware);
+    }
+
+    public function testWithSessionPersistenceInterfaceServiceAndWithSaveHandlerInterfaceService()
+    {
+        $saveHandler = $this->prophesize(SaveHandlerInterface::class)->reveal();
+        $persistence = $this->prophesize(SessionPersistenceInterface::class)->reveal();
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get(SessionPersistenceInterface::class)->willReturn($persistence);
+        $container->has(SaveHandlerInterface::class)->willReturn(true);
+        $container->get(SaveHandlerInterface::class)->willReturn($saveHandler);
+
+        $factory = new SessionMiddlewareFactory();
         $middleware = $factory($container->reveal());
 
         $this->assertInstanceOf(SessionMiddleware::class, $middleware);

--- a/test/SessionMiddlewareTest.php
+++ b/test/SessionMiddlewareTest.php
@@ -15,15 +15,19 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Zend\Expressive\Session\LazySession;
+use Zend\Expressive\Session\SaveHandlerInterface;
 use Zend\Expressive\Session\SessionMiddleware;
 use Zend\Expressive\Session\SessionPersistenceInterface;
 
+/**
+ * @runTestsInSeparateProcesses
+ */
 class SessionMiddlewareTest extends TestCase
 {
     public function testConstructorAcceptsConcretePersistenceInstances()
     {
         $persistence = $this->prophesize(SessionPersistenceInterface::class)->reveal();
-        $middleware = new SessionMiddleware($persistence);
+        $middleware = new SessionMiddleware($persistence, null);
         $this->assertAttributeSame($persistence, 'persistence', $middleware);
     }
 
@@ -52,7 +56,16 @@ class SessionMiddlewareTest extends TestCase
             )
             ->will([$response, 'reveal']);
 
-        $middleware = new SessionMiddleware($persistence->reveal());
+        $middleware = new SessionMiddleware($persistence->reveal(), null);
         $this->assertSame($response->reveal(), $middleware->process($request->reveal(), $handler->reveal()));
+    }
+
+    public function testConstructorAcceptsConcreteSaveHandlerInstances()
+    {
+        $saveHandler = $this->prophesize(SaveHandlerInterface::class)->reveal();
+        $persistence = $this->prophesize(SessionPersistenceInterface::class)->reveal();
+
+        $middleware = new SessionMiddleware($persistence, $saveHandler);
+        $this->assertAttributeSame($persistence, 'persistence', $middleware);
     }
 }


### PR DESCRIPTION
This is a new feature that allows you to use your own session save handler.  
See: http://php.net/session_set_save_handler  
To use, you need the following:
- The handler class must implement the interface `Zend\Expressive\Session\SessionHandlerInterface`
- The class must be added to the container configuration as a factory or invokable.
```php
return [
    'dependencies' => [
        'factories' => [
            \Zend\Expressive\Session\SaveHandlerInterface::class => MyOwnSaveHandler::class,
        ],
    ],
];
```
- If the above are correct, it will use your own session save handler