### PR TITLE
add short-circuit return for isRegenerated

### DIFF
--- a/src/LazySession.php
+++ b/src/LazySession.php
@@ -55,7 +55,11 @@ final class LazySession implements
 
     public function isRegenerated() : bool
     {
-        return $this->getProxiedSession()->isRegenerated();
+        if (! $this->proxiedSession) {
+            return false;
+        }
+
+        return $this->proxiedSession->isRegenerated();
     }
 
     public function toArray() : array
@@ -94,13 +98,11 @@ final class LazySession implements
             return false;
         }
 
-        $proxy = $this->getProxiedSession();
-
-        if ($proxy->isRegenerated()) {
+        if ($this->proxiedSession->isRegenerated()) {
             return true;
         }
 
-        return $proxy->hasChanged();
+        return $this->proxiedSession->hasChanged();
     }
 
     /**


### PR DESCRIPTION
- `isRegenerated()`: if there is no proxiedSession then the `regenerate()` method has not been called (because it would have created the proxy), so it should return false without triggering a proxy instantiation by itself. (the proxy instance is encapsulated, the only way to "regenerate" it is by calling the lazy wrapper/decorator's regenerate() method)
- `hasChanged()`: replaced the `getProxiedSession()` calls with the `proxiedSession` property as the preceding "if" condition ensures we have an instance at this point.