### PR TITLE
Allow a different SESSION_ATTRIBUTE to be used if the class is extended

### DIFF
--- a/src/SessionMiddleware.php
+++ b/src/SessionMiddleware.php
@@ -31,7 +31,7 @@ class SessionMiddleware implements MiddlewareInterface
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
         $session = new LazySession($this->persistence, $request);
-        $response = $handler->handle($request->withAttribute(self::SESSION_ATTRIBUTE, $session));
+        $response = $handler->handle($request->withAttribute(static::SESSION_ATTRIBUTE, $session));
         return $this->persistence->persistSession($session, $response);
     }
 }


### PR DESCRIPTION
At present there's no way to change the value of `SESSION_ATTRIBUTE` in `SessionMiddleware` if the class is extended. This is needed in my case where multiple sessions are used in the same pipeline, each with different persistent storage and expiry requirements.

A change to use late static binding would allow us to declare our own value in the final class, whilst having no functional change to existing class.

An example of its use:
```
<?php
declare(strict_types=1);

namespace App\Middleware\Session;

use App\Service\Session\Cookie as CookieSessionPersistence;
use Zend\Expressive\Session\SessionMiddleware;

class General extends SessionMiddleware
{
    public const SESSION_ATTRIBUTE = 'cookie';

    /**
     * General constructor.
     * @param CookieSessionPersistence $persistence
     */
    public function __construct(CookieSessionPersistence $persistence)
    {
        parent::__construct($persistence);
    }
}
```

Provide a narrative description of what you are trying to accomplish:

- [ ] Are you fixing a bug?
  - [ ] Detail how the bug is invoked currently.
  - [ ] Detail the original, incorrect behavior.
  - [ ] Detail the new, expected behavior.
  - [ ] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

- [x] Are you creating a new feature?
  - [x] Why is the new feature needed? What purpose does it serve?
  - [x] How will users use the new feature?
  - [x] Base your feature on the `develop` branch, and submit against that branch.
  - [x] Add only one feature per pull request; split multiple features over multiple pull requests
  - [ ] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.

- [ ] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->

- [ ] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
