### PR TITLE
Add interfaces to initialise session ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- Added `InitializeSessionIdInterface` and `InitializePersistenceIdInterface`. These add `initializeId()` methods to
+  session and persistence, allowing developers to access new or regenerated session IDs before the session is persisted.
 
 ### Changed
 

--- a/src/Exception/NotInitializableException.php
+++ b/src/Exception/NotInitializableException.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-session for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-session/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Session\Exception;
+
+use RuntimeException;
+use Zend\Expressive\Session\SessionPersistenceInterface;
+use Zend\Expressive\Session\InitializePersistenceIdInterface;
+
+final class NotInitializableException extends RuntimeException implements ExceptionInterface
+{
+    public static function invalidPersistence(SessionPersistenceInterface $persistence) : self
+    {
+        return new self(sprintf(
+            "Persistence '%s' does not implement '%s'",
+            get_class($persistence),
+            InitializePersistenceIdInterface::class
+        ));
+    }
+}

--- a/src/InitializePersistenceIdInterface.php
+++ b/src/InitializePersistenceIdInterface.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-session for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-session/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Session;
+
+interface InitializePersistenceIdInterface
+{
+    /**
+     * Returns new instance with id generated / regenerated, if required
+     *
+     * @param SessionInterface $session
+     * @return SessionInterface
+     */
+    public function initializeId(SessionInterface $session) : SessionInterface;
+}

--- a/src/InitializeSessionIdInterface.php
+++ b/src/InitializeSessionIdInterface.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-session for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-session/blob/master/LICENSE.md New BSD License
+ */
+
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Session;
+
+interface InitializeSessionIdInterface
+{
+    /**
+     * Returns id of session, generating / regenerating it required
+     *
+     * @return string
+     */
+    public function initializeId() : string;
+}

--- a/src/LazySession.php
+++ b/src/LazySession.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Zend\Expressive\Session;
 
 use Psr\Http\Message\ServerRequestInterface;
+use Zend\Expressive\Session\Exception\NotInitializableException;
 
 /**
  * Proxy to an underlying SessionInterface implementation.
@@ -22,7 +23,8 @@ use Psr\Http\Message\ServerRequestInterface;
 final class LazySession implements
     SessionCookiePersistenceInterface,
     SessionIdentifierAwareInterface,
-    SessionInterface
+    SessionInterface,
+    InitializeSessionIdInterface
 {
     /**
      * @var SessionPersistenceInterface
@@ -143,6 +145,17 @@ final class LazySession implements
             ? $proxiedSession->getSessionLifetime()
             : 0;
     }
+
+    public function initializeId(): string
+    {
+        if (! $this->persistence instanceof InitializePersistenceIdInterface) {
+            throw NotInitializableException::invalidPersistence($this->persistence);
+        }
+
+        $this->proxiedSession = $this->persistence->initializeId($this->getProxiedSession());
+        return $this->proxiedSession->getId();
+    }
+
 
     private function getProxiedSession() : SessionInterface
     {


### PR DESCRIPTION
This PR adds two interfaces:

* `InitializeSessionIdInterface` adds an `initialiseId()` method to sessions. This returns the session ID, creating a new ID if not present or regenerating an existing one
* `InitializePersistenceIdInterface` adds an `initialiseId()` method to persistence. This returns a new `Session` with the ID generated / regenerated if required.

`LazySession` can now initialise the ID if the persistence supports it.

I outlined a couple of use cases on the [forum](https://discourse.zendframework.com/t/make-lazysession-startable/1156/3383). Though when I wrote that I was thinking the session would also needed to be started. I've since realised that isn't required.
